### PR TITLE
Fix bug where trailing dash in boundary will cause MessagingException

### DIFF
--- a/src/ring/multipart_mixed_params.clj
+++ b/src/ring/multipart_mixed_params.clj
@@ -32,7 +32,7 @@
   "Parse a mutlipart/mixed request"
   [request & [limit]]
   (let [multipart  (MimeMultipart. (ByteArrayDataSource. (input-stream request limit)
-                                                         "multipart/mixed"))]
+                                                         (:content-type request)))]
     (if (.isComplete multipart)
       (apply merge-with concat (parts-sequence multipart))
       (throw (javax.mail.MessagingException. "Incomplete request received")))))

--- a/test/multipart/resources/single-with-trailing-boundary-dash.part
+++ b/test/multipart/resources/single-with-trailing-boundary-dash.part
@@ -1,0 +1,9 @@
+Content-type: multipart/mixed; boundary="vdowbVAIccYaqDmTfl5KKWvVIYXd2fXYJHu7J--"
+--vdowbVAIccYaqDmTfl5KKWvVIYXd2fXYJHu7J--
+Content-Disposition: form-data; name="foo"
+Content-Type: application/json; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+{}
+
+--vdowbVAIccYaqDmTfl5KKWvVIYXd2fXYJHu7J----


### PR DESCRIPTION
Trailing dashes in the boundary causes `javax.mail.internet.MimeMultipart::parsebm` method to fail with `javax.mail.MessagingException: Missing start boundary` unless provided with the boundary contained within `Content-Type`.